### PR TITLE
Added new Types overloads

### DIFF
--- a/Samples/SampleApp.Tests/DomainTests.cs
+++ b/Samples/SampleApp.Tests/DomainTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace SampleApp.Tests
 {
-    using System.Linq;
     using NUnit.Framework;
     using SampleApp.Domain;
     using TestStack.ConventionTests;
@@ -15,7 +14,7 @@
         public DomainTests()
         {
             domainEntities = Types.InAssemblyOf<DomainClass>("Domain Entities", 
-                types => types.Where(t=>t.Namespace.StartsWith("SampleApp.Domain")));
+                type => type.Namespace.StartsWith("SampleApp.Domain"));
         }
 
         [Test]

--- a/TestStack.ConventionTests.Tests/CsvReportTests.cs
+++ b/TestStack.ConventionTests.Tests/CsvReportTests.cs
@@ -14,12 +14,12 @@
         [Test]
         public void Can_run_convention_with_simple_reporter()
         {
-            Convention.IsWithApprovedExeptions(new CollectionsRelationsConvention(), new Types("Entities")
-            {
-                TypesToVerify =
-                    typeof (Leaf).Assembly.GetExportedTypes()
-                        .Where(t => t.Namespace == typeof (Leaf).Namespace).ToArray()
-            }, new CsvReporter());
+            var typesToVerify = typeof (Leaf).Assembly.GetExportedTypes()
+                .Where(t => t.Namespace == typeof (Leaf).Namespace);
+
+            Convention.IsWithApprovedExeptions(new CollectionsRelationsConvention(),
+                new Types(typesToVerify, "Entities"),
+                new CsvReporter());
         }
     }
 }

--- a/TestStack.ConventionTests.Tests/TypeBasedConventions.cs
+++ b/TestStack.ConventionTests.Tests/TypeBasedConventions.cs
@@ -1,6 +1,5 @@
 ﻿namespace TestStack.ConventionTests.Tests
 {
-    using System.Linq;
     using ApprovalTests;
     using ApprovalTests.Reporters;
     using NUnit.Framework;
@@ -17,7 +16,7 @@
         public TypeBasedConventions()
         {
             nhibernateEntities = Types.InAssemblyOf<SampleDomainClass>("nHibernate Entitites",
-                types => types.Where(t => t.IsConcreteClass() && t.Namespace == typeof (SampleDomainClass).Namespace));
+                type => type.IsConcreteClass() && type.Namespace == typeof (SampleDomainClass).Namespace);
         }
 
         [Test]

--- a/TestStack.ConventionTests/ConventionData/TypeExtensions.cs
+++ b/TestStack.ConventionTests/ConventionData/TypeExtensions.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using System.Runtime.CompilerServices;
     using System.Text;
     using System.Text.RegularExpressions;
 
@@ -22,6 +23,11 @@
         public static bool IsStatic(this Type type)
         {
             return type.IsClass && !(type.IsSealed && type.IsAbstract);
+        }
+
+        public static bool IsCompilerGenerated(this Type type)
+        {
+            return type.IsDefined(typeof(CompilerGeneratedAttribute), true);
         }
 
         public static bool HasDefaultConstructor(this Type type)

--- a/TestStack.ConventionTests/ConventionData/Types.cs
+++ b/TestStack.ConventionTests/ConventionData/Types.cs
@@ -2,8 +2,9 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel;
     using System.Linq;
-    using System.Runtime.CompilerServices;
+    using System.Reflection;
 
     /// <summary>
     ///     This is where we set what our convention is all about.
@@ -19,31 +20,190 @@
 
         public string Description { get; private set; }
 
-        public bool HasData {get { return TypesToVerify.Any(); }}
-
-        public static Types InAssemblyOf<T>(bool excludeCompilerGeneratedTypes = true)
+        public bool HasData
         {
-            var assembly = typeof(T).Assembly;
-            var typesToVerify = assembly.GetTypes();
-            if (excludeCompilerGeneratedTypes)
-            {
-                typesToVerify = typesToVerify
-                    .Where(t => !t.GetCustomAttributes(typeof (CompilerGeneratedAttribute), true).Any())
-                    .ToArray();
-            }
-            return new Types(assembly.GetName().Name)
-            {
-                TypesToVerify = typesToVerify
-            };
+            get { return TypesToVerify.Any(); }
         }
 
+        /// <summary>
+        /// Gets a filtered list of types from the assembly of the specified
+        /// type, <typeparam name="T" />, using the specified <param name="predicate" />.
+        /// </summary>
+        /// <typeparam name="T">A type residing in the assembly to get types from.</typeparam>
+        /// <param name="predicate">A function to test each type for a condition.</param>
+        public static Types InAssemblyOf<T>(Func<Type, bool> predicate)
+        {
+            return InAssemblyOf(typeof(T), predicate);
+        }
+
+        /// <summary>
+        /// Gets a filtered list of types from the assembly of the specified
+        /// type, <param name="type" />, using the specified <param name="predicate" />.
+        /// </summary>
+        /// <param name="type">A type residing in the assembly to get types from.</param>
+        /// <param name="predicate">A function to test each type for a condition.</param>
+        public static Types InAssemblyOf(Type type, Func<Type, bool> predicate)
+        {
+            return InAssembly(type.Assembly, predicate);
+        }
+
+        /// <summary>
+        /// Gets a filtered list of types from the specified <param name="assembly" /> using the specified <param name="predicate" />.
+        /// </summary>
+        /// <param name="assembly">The assembly to get types from.</param>
+        /// <param name="predicate">A function to test each type for a condition.</param>
+        public static Types InAssembly(Assembly assembly, Func<Type, bool> predicate)
+        {
+            return InAssembly(assembly, GetAssemblyName(assembly), predicate);
+        }
+
+        /// <summary>
+        /// Gets a filtered list of types from the assembly of the specified
+        /// type, <typeparam name="T" />, using the specified <param name="predicate" />.
+        /// </summary>
+        /// <typeparam name="T">A type residing in the assembly to get types from.</typeparam>
+        /// <param name="descriptionOfTypes">A description of the matched types.</param>
+        /// <param name="predicate">A function to test each type for a condition.</param>
+        public static Types InAssemblyOf<T>(string descriptionOfTypes, Func<Type, bool> predicate)
+        {
+            return InAssemblyOf(typeof(T), descriptionOfTypes, predicate);
+        }
+
+        /// <summary>
+        /// Gets a filtered list of types from the assembly of the specified
+        /// type, <param name="type" />, using the specified <param name="predicate" />.
+        /// </summary>
+        /// <param name="type">A type residing in the assembly to get types from.</param>
+        /// <param name="descriptionOfTypes">A description of the matched types.</param>
+        /// <param name="predicate">A function to test each type for a condition.</param>
+        public static Types InAssemblyOf(Type type, string descriptionOfTypes, Func<Type, bool> predicate)
+        {
+            return InAssembly(type.Assembly, descriptionOfTypes, predicate);
+        }
+
+        /// <summary>
+        /// Gets a filtered list of types from the specified <param name="assembly" /> using the specified <param name="predicate" />.
+        /// </summary>
+        /// <param name="assembly">The assembly to get types from.</param>
+        /// <param name="descriptionOfTypes">A description of the matched types.</param>
+        /// <param name="predicate">A function to test each type for a condition.</param>
+        public static Types InAssembly(Assembly assembly, string descriptionOfTypes, Func<Type, bool> predicate)
+        {
+            return InAssemblies(new[] { assembly }, descriptionOfTypes, predicate);
+        }
+
+        /// <summary>
+        /// Gets an optionally filtered list of types from the specified <param name="assemblies" /> using the specified <param name="predicate" />.
+        /// </summary>
+        /// <param name="assemblies">A list of assemblies to get types from.</param>
+        /// <param name="descriptionOfTypes">A description of the matched types.</param>
+        /// <param name="predicate">A function to test each type for a condition.</param>
+        public static Types InAssemblies(IEnumerable<Assembly> assemblies, string descriptionOfTypes, Func<Type, bool> predicate)
+        {
+            return InCollection(assemblies.SelectMany(x => x.GetTypes()).Where(predicate), descriptionOfTypes);
+        }
+
+        /// <summary>
+        /// Gets an optionally filtered list of types from the assembly of the specified type, <typeparam name="T" />.
+        /// </summary>
+        /// <typeparam name="T">A type residing in the assembly to get types from.</typeparam>
+        /// <param name="excludeCompilerGeneratedTypes">Compiler generated types will be excluded if set to <c>true</c>.</param>
+        public static Types InAssemblyOf<T>(bool excludeCompilerGeneratedTypes = true)
+        {
+            return InAssemblyOf(typeof(T), excludeCompilerGeneratedTypes);
+        }
+
+        /// <summary>
+        /// Gets an optionally filtered list of types from the assembly of the specified type, <param name="type" />.
+        /// </summary>
+        /// <param name="type">A type residing in the assembly to get types from.</param>
+        /// <param name="excludeCompilerGeneratedTypes">Compiler generated types will be excluded if set to <c>true</c>.</param>
+        public static Types InAssemblyOf(Type type, bool excludeCompilerGeneratedTypes = true)
+        {
+            return InAssembly(type.Assembly, excludeCompilerGeneratedTypes);
+        }
+
+        /// <summary>
+        /// Gets an optionally filtered list of types from the specified <param name="assembly" />.
+        /// </summary>
+        /// <param name="assembly">The assembly to get types from.</param>
+        /// <param name="excludeCompilerGeneratedTypes">Compiler generated types will be excluded if set to <c>true</c>.</param>
+        public static Types InAssembly(Assembly assembly, bool excludeCompilerGeneratedTypes = true)
+        {
+            return InAssembly(assembly, GetAssemblyName(assembly), excludeCompilerGeneratedTypes);
+        }
+
+        /// <summary>
+        /// Gets an optionally filtered list of types from the assembly of the specified
+        /// type, <typeparam name="T" />, using the specified <param name="types" /> filter.
+        /// </summary>
+        /// <typeparam name="T">A type residing in the assembly to get types from.</typeparam>
+        /// <param name="descriptionOfTypes">A description of the matched types.</param>
+        /// <param name="types">A function to filter or add matched types.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("This method is obsolete and should not be used. Use the overload with a predicate instead.")]
         public static Types InAssemblyOf<T>(string descriptionOfTypes, Func<IEnumerable<Type>, IEnumerable<Type>> types)
         {
-            var assembly = typeof (T).Assembly;
-            return new Types(descriptionOfTypes)
-            {
-                TypesToVerify = types(assembly.GetTypes()).ToArray()
-            };
+            return InCollection(types(typeof(T).Assembly.GetTypes()), descriptionOfTypes);
+        }
+
+        /// <summary>
+        /// Gets an optionally filtered list of types from the assembly of the specified type, <typeparam name="T" />.
+        /// </summary>
+        /// <typeparam name="T">A type residing in the assembly to get types from.</typeparam>
+        /// <param name="descriptionOfTypes">A description of the matched types.</param>
+        /// <param name="excludeCompilerGeneratedTypes">Compiler generated types will be excluded if set to <c>true</c>.</param>
+        public static Types InAssemblyOf<T>(string descriptionOfTypes, bool excludeCompilerGeneratedTypes = true)
+        {
+            return InAssemblyOf(typeof(T), descriptionOfTypes, excludeCompilerGeneratedTypes);
+        }
+
+        /// <summary>
+        /// Gets an optionally filtered list of types from the assembly of the specified type, <param name="type" />.
+        /// </summary>
+        /// <param name="type">A type residing in the assembly to get types from.</param>
+        /// <param name="descriptionOfTypes">A description of the matched types.</param>
+        /// <param name="excludeCompilerGeneratedTypes">Compiler generated types will be excluded if set to <c>true</c>.</param>
+        public static Types InAssemblyOf(Type type, string descriptionOfTypes, bool excludeCompilerGeneratedTypes = true)
+        {
+            return InAssembly(type.Assembly, descriptionOfTypes, excludeCompilerGeneratedTypes);
+        }
+
+        /// <summary>
+        /// Gets an optionally filtered list of types from the specified <param name="assembly" />.
+        /// </summary>
+        /// <param name="assembly">The assembly to get types from.</param>
+        /// <param name="descriptionOfTypes">A description of the matched types.</param>
+        /// <param name="excludeCompilerGeneratedTypes">Compiler generated types will be excluded if set to <c>true</c>.</param>
+        public static Types InAssembly(Assembly assembly, string descriptionOfTypes, bool excludeCompilerGeneratedTypes = true)
+        {
+            return InAssemblies(new[] { assembly }, descriptionOfTypes, excludeCompilerGeneratedTypes);
+        }
+
+        /// <summary>
+        /// Gets an optionally filtered list of types from the specified <param name="assemblies" />.
+        /// </summary>
+        /// <param name="assemblies">A list of assemblies to get types from.</param>
+        /// <param name="descriptionOfTypes">A description of the matched types.</param>
+        /// <param name="excludeCompilerGeneratedTypes">Compiler generated types will be excluded if set to <c>true</c>.</param>
+        public static Types InAssemblies(IEnumerable<Assembly> assemblies, string descriptionOfTypes, bool excludeCompilerGeneratedTypes = true)
+        {
+            return InAssemblies(assemblies, descriptionOfTypes, type => !(excludeCompilerGeneratedTypes && type.IsCompilerGenerated()));
+        }
+
+        /// <summary>
+        /// Gets a list of types from the specified <param name="types" /> collection.
+        /// </summary>
+        /// <param name="types">The types.</param>
+        /// <param name="descriptionOfTypes">A description of the matched types.</param>
+        public static Types InCollection(IEnumerable<Type> types, string descriptionOfTypes)
+        {
+            return new Types(descriptionOfTypes) { TypesToVerify = types.ToArray() };
+        }
+
+        private static string GetAssemblyName(Assembly assembly)
+        {
+            return assembly.GetName().Name;
         }
     }
 }

--- a/TestStack.ConventionTests/ConventionData/Types.cs
+++ b/TestStack.ConventionTests/ConventionData/Types.cs
@@ -1,6 +1,7 @@
 ﻿namespace TestStack.ConventionTests.ConventionData
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Linq;
@@ -9,7 +10,7 @@
     /// <summary>
     ///     This is where we set what our convention is all about.
     /// </summary>
-    public class Types : IConventionData
+    public class Types : IConventionData, IEnumerable<Type>
     {
         public Types(string descriptionOfTypes) : this(Enumerable.Empty<Type>(), descriptionOfTypes)
         {
@@ -21,7 +22,7 @@
             Description = descriptionOfTypes;
         }
 
-        public Type[] TypesToVerify { get; private set; }
+        public IEnumerable<Type> TypesToVerify { get; private set; }
 
         public string Description { get; private set; }
 
@@ -209,6 +210,16 @@
         private static string GetAssemblyName(Assembly assembly)
         {
             return assembly.GetName().Name;
+        }
+
+        public IEnumerator<Type> GetEnumerator()
+        {
+            return TypesToVerify.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 }

--- a/TestStack.ConventionTests/ConventionData/Types.cs
+++ b/TestStack.ConventionTests/ConventionData/Types.cs
@@ -11,12 +11,17 @@
     /// </summary>
     public class Types : IConventionData
     {
-        public Types(string descriptionOfTypes)
+        public Types(string descriptionOfTypes) : this(Enumerable.Empty<Type>(), descriptionOfTypes)
         {
+        }
+
+        public Types(IEnumerable<Type> types, string descriptionOfTypes)
+        {
+            TypesToVerify = types.ToArray();
             Description = descriptionOfTypes;
         }
 
-        public Type[] TypesToVerify { get; set; }
+        public Type[] TypesToVerify { get; private set; }
 
         public string Description { get; private set; }
 
@@ -198,7 +203,7 @@
         /// <param name="descriptionOfTypes">A description of the matched types.</param>
         public static Types InCollection(IEnumerable<Type> types, string descriptionOfTypes)
         {
-            return new Types(descriptionOfTypes) { TypesToVerify = types.ToArray() };
+            return new Types(types, descriptionOfTypes);
         }
 
         private static string GetAssemblyName(Assembly assembly)


### PR DESCRIPTION
Here's a couple of (in my opinion) missing overloads for `Types`.

This also fixes half of #56

I went a bit overboard with breaking changes here. They are contained in the three last commits. If you want me to I can strip them out :smile: